### PR TITLE
Fix test case errors

### DIFF
--- a/crypto/encoding/amino/amino.go
+++ b/crypto/encoding/amino/amino.go
@@ -33,6 +33,7 @@ func init() {
 	nameTable[reflect.TypeOf(ed25519.PubKeyEd25519{})] = ed25519.PubKeyAminoName
 	nameTable[reflect.TypeOf(secp256k1.PubKeySecp256k1{})] = secp256k1.PubKeyAminoName
 	nameTable[reflect.TypeOf(multisig.PubKeyMultisigThreshold{})] = multisig.PubKeyMultisigThresholdAminoRoute
+	nameTable[reflect.TypeOf(p256.PubKeyP256{})] = p256.PubKeyAminoName
 }
 
 // PubkeyAminoName returns the amino route of a pubkey

--- a/crypto/encoding/amino/encode_test.go
+++ b/crypto/encoding/amino/encode_test.go
@@ -56,6 +56,8 @@ func ExamplePrintRegisteredTypes() {
 	//| PubKeyMultisigThreshold | tendermint/PubKeyMultisigThreshold | 0x22C1F7E2 | variable |  |
 	//| PrivKeyEd25519 | tendermint/PrivKeyEd25519 | 0xA3288910 | 0x40 |  |
 	//| PrivKeySecp256k1 | tendermint/PrivKeySecp256k1 | 0xE1B0F79B | 0x20 |  |
+	//| PrivKeyP256 | amo/PrivKeyP256 | 0xC8ACEE31 | 0x20 |  |
+	//| PubKeyP256 | amo/PubKeyP256 | 0x496DC48E | 0x41 |  |
 }
 
 func TestKeyEncodings(t *testing.T) {

--- a/crypto/encoding/amino/encode_test.go
+++ b/crypto/encoding/amino/encode_test.go
@@ -1,15 +1,16 @@
 package cryptoAmino
 
 import (
+	"github.com/amolabs/tendermint-amo/crypto/p256"
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/amolabs/tendermint-amo/crypto"
 	"github.com/amolabs/tendermint-amo/crypto/ed25519"
 	"github.com/amolabs/tendermint-amo/crypto/multisig"
 	"github.com/amolabs/tendermint-amo/crypto/secp256k1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type byter interface {
@@ -77,6 +78,12 @@ func TestKeyEncodings(t *testing.T) {
 			pubSize:  38,
 			sigSize:  65,
 		},
+		{
+			privKey:  p256.GenPrivKey(),
+			privSize: 37,
+			pubSize:  70,
+			sigSize:  65,
+		},
 	}
 
 	for tcIndex, tc := range cases {
@@ -138,6 +145,7 @@ func TestPubkeyAminoName(t *testing.T) {
 		{ed25519.PubKeyEd25519{}, ed25519.PubKeyAminoName, true},
 		{secp256k1.PubKeySecp256k1{}, secp256k1.PubKeyAminoName, true},
 		{multisig.PubKeyMultisigThreshold{}, multisig.PubKeyMultisigThresholdAminoRoute, true},
+		{p256.PubKeyP256{}, p256.PubKeyAminoName, true},
 	}
 	for i, tc := range tests {
 		got, found := PubkeyAminoName(cdc, tc.key)

--- a/crypto/encoding/amino/encode_test.go
+++ b/crypto/encoding/amino/encode_test.go
@@ -1,13 +1,13 @@
 package cryptoAmino
 
 import (
-	"github.com/amolabs/tendermint-amo/crypto/p256"
 	"os"
 	"testing"
 
 	"github.com/amolabs/tendermint-amo/crypto"
 	"github.com/amolabs/tendermint-amo/crypto/ed25519"
 	"github.com/amolabs/tendermint-amo/crypto/multisig"
+	"github.com/amolabs/tendermint-amo/crypto/p256"
 	"github.com/amolabs/tendermint-amo/crypto/secp256k1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/crypto/p256/p256.go
+++ b/crypto/p256/p256.go
@@ -12,18 +12,29 @@ import (
 	"math/big"
 )
 
-type PrivKeyP256 [32]byte
-type PubKeyP256 [65]byte
-
 var (
 	c = elliptic.P256()
 	h = tmc.Sha256
 )
 
+var cdc = amino.NewCodec()
+
 const (
 	PrivKeyAminoName = "amo/PrivKeyP256"
 	PubKeyAminoName = "amo/PubKeyP256"
+	SignatureSize = 64
+	PribKeyP256Size = 32
+	PubKeyP256Size = 65
 )
+
+type PrivKeyP256 [PribKeyP256Size]byte
+type PubKeyP256 [PubKeyP256Size]byte
+
+func init() {
+	cdc.RegisterInterface((*tmc.PubKey)(nil), nil)
+	cdc.RegisterInterface((*tmc.PrivKey)(nil), nil)
+	RegisterAmino(cdc)
+}
 
 func RegisterAmino(cdc *amino.Codec) {
 	cdc.RegisterConcrete(PrivKeyP256{}, PrivKeyAminoName, nil)
@@ -52,7 +63,7 @@ func genPrivKey(rand io.Reader) PrivKeyP256 {
 }
 
 func (privKey PrivKeyP256) Bytes() []byte {
-	return privKey[:]
+	return cdc.MustMarshalBinaryBare(privKey)
 }
 
 func (privKey PrivKeyP256) ToECDSA() *ecdsa.PrivateKey {

--- a/crypto/p256/p256.go
+++ b/crypto/p256/p256.go
@@ -118,7 +118,7 @@ func (pubKey PubKeyP256) Address() tmc.Address {
 }
 
 func (pubKey PubKeyP256) Bytes() []byte {
-	return pubKey[:]
+	return cdc.MustMarshalBinaryBare(pubKey)
 }
 
 func (pubKey PubKeyP256) ToECDSA() *ecdsa.PublicKey {

--- a/crypto/p256/p256_test.go
+++ b/crypto/p256/p256_test.go
@@ -1,23 +1,27 @@
 package p256
 
 import (
-	"encoding/hex"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/amolabs/tendermint-amo/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestGenPrivKey(t *testing.T) {
-	r := require.New(t)
-	privKey := PrivKeyP256{}
-	privKeyBytes, _ := hex.DecodeString("CDDB6810F12C7713B97D685316EE56086C463449E03BBB6A256CC6547B342A70")
-	privKey.SetBytes(privKeyBytes)
+func TestSignAndVerifyP256(t *testing.T) {
+	privKey := GenPrivKey()
 	pubKey := privKey.PubKey()
-	pubKeyBytes, _ := hex.DecodeString("047E10BF3D00C47403FD73AAAAA46B9CF9E680A80E259658E5FA0699FA3658F712ED4025E469F3CD0E9B872DBCA44158A450A04CAEA48005B52C541EAD92FCF581")
-	r.Equal(pubKey.Bytes(), pubKeyBytes)
-	msg := []byte("aaa")
+
+	msg := crypto.CRandBytes(128)
 	sig, err := privKey.Sign(msg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	r.True(pubKey.VerifyBytes(msg, sig))
+	require.Nil(t, err)
+
+	// Test the signature
+	assert.True(t, pubKey.VerifyBytes(msg, sig))
+
+	// Mutate the signature, just one bit.
+	// TODO: Replace this with a much better fuzzer, tendermint/ed25519/issues/10
+	sig[7] ^= byte(0x01)
+
+	assert.False(t, pubKey.VerifyBytes(msg, sig))
 }

--- a/p2p/key.go
+++ b/p2p/key.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"github.com/amolabs/tendermint-amo/crypto/p256"
 	"io/ioutil"
 
 	"github.com/amolabs/tendermint-amo/crypto"
+	"github.com/amolabs/tendermint-amo/crypto/ed25519"
 	cmn "github.com/amolabs/tendermint-amo/libs/common"
 )
 
@@ -71,7 +71,7 @@ func LoadNodeKey(filePath string) (*NodeKey, error) {
 }
 
 func genNodeKey(filePath string) (*NodeKey, error) {
-	privKey := p256.GenPrivKey()
+	privKey := ed25519.GenPrivKey()
 	nodeKey := &NodeKey{
 		PrivKey: privKey,
 	}

--- a/privval/file.go
+++ b/privval/file.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/amolabs/tendermint-amo/crypto/p256"
 	"io/ioutil"
 	"time"
 
 	"github.com/amolabs/tendermint-amo/crypto"
+	"github.com/amolabs/tendermint-amo/crypto/ed25519"
 	cmn "github.com/amolabs/tendermint-amo/libs/common"
 	"github.com/amolabs/tendermint-amo/types"
 	tmtime "github.com/amolabs/tendermint-amo/types/time"
@@ -143,7 +143,7 @@ type FilePV struct {
 // GenFilePV generates a new validator with randomly generated private key
 // and sets the filePaths, but does not call Save().
 func GenFilePV(keyFilePath, stateFilePath string) *FilePV {
-	privKey := p256.GenPrivKey()
+	privKey := ed25519.GenPrivKey()
 
 	return &FilePV{
 		Key: FilePVKey{

--- a/types/priv_validator.go
+++ b/types/priv_validator.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/amolabs/tendermint-amo/crypto/p256"
 
 	"github.com/amolabs/tendermint-amo/crypto"
+	"github.com/amolabs/tendermint-amo/crypto/ed25519"
 )
 
 // PrivValidator defines the functionality of a local Tendermint validator
@@ -49,7 +49,7 @@ type MockPV struct {
 }
 
 func NewMockPV() *MockPV {
-	return &MockPV{p256.GenPrivKey(), false, false}
+	return &MockPV{ed25519.GenPrivKey(), false, false}
 }
 
 // NewMockPVWithParams allows one to create a MockPV instance, but with finer
@@ -124,5 +124,5 @@ func (pv *erroringMockPV) SignProposal(chainID string, proposal *Proposal) error
 
 // NewErroringMockPV returns a MockPV that fails on each signing request. Again, for testing only.
 func NewErroringMockPV() *erroringMockPV {
-	return &erroringMockPV{&MockPV{p256.GenPrivKey(), false, false}}
+	return &erroringMockPV{&MockPV{ed25519.GenPrivKey(), false, false}}
 }

--- a/types/protobuf.go
+++ b/types/protobuf.go
@@ -2,13 +2,13 @@ package types
 
 import (
 	"fmt"
-	"github.com/amolabs/tendermint-amo/crypto/p256"
 	"reflect"
 	"time"
 
 	abci "github.com/amolabs/tendermint-amo/abci/types"
 	"github.com/amolabs/tendermint-amo/crypto"
 	"github.com/amolabs/tendermint-amo/crypto/ed25519"
+	"github.com/amolabs/tendermint-amo/crypto/p256"
 	"github.com/amolabs/tendermint-amo/crypto/secp256k1"
 )
 
@@ -23,14 +23,14 @@ const (
 const (
 	ABCIPubKeyTypeEd25519   = "ed25519"
 	ABCIPubKeyTypeSecp256k1 = "secp256k1"
-	ABCIPubKeyTypeP256 = "p256"
+	ABCIPubKeyTypeP256      = "p256"
 )
 
 // TODO: Make non-global by allowing for registration of more pubkey types
 var ABCIPubKeyTypesToAminoNames = map[string]string{
 	ABCIPubKeyTypeEd25519:   ed25519.PubKeyAminoName,
 	ABCIPubKeyTypeSecp256k1: secp256k1.PubKeyAminoName,
-	ABCIPubKeyTypeP256: p256.PubKeyAminoName,
+	ABCIPubKeyTypeP256:      p256.PubKeyAminoName,
 }
 
 //-------------------------------------------------------
@@ -114,7 +114,7 @@ func (tm2pb) PubKey(pubKey crypto.PubKey) abci.PubKey {
 		}
 	case p256.PubKeyP256:
 		return abci.PubKey{
-			Type:ABCIPubKeyTypeP256,
+			Type: ABCIPubKeyTypeP256,
 			Data: pk[:],
 		}
 	default:

--- a/types/protobuf.go
+++ b/types/protobuf.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"github.com/amolabs/tendermint-amo/crypto/p256"
 	"reflect"
 	"time"
 
@@ -22,12 +23,14 @@ const (
 const (
 	ABCIPubKeyTypeEd25519   = "ed25519"
 	ABCIPubKeyTypeSecp256k1 = "secp256k1"
+	ABCIPubKeyTypeP256 = "p256"
 )
 
 // TODO: Make non-global by allowing for registration of more pubkey types
 var ABCIPubKeyTypesToAminoNames = map[string]string{
 	ABCIPubKeyTypeEd25519:   ed25519.PubKeyAminoName,
 	ABCIPubKeyTypeSecp256k1: secp256k1.PubKeyAminoName,
+	ABCIPubKeyTypeP256: p256.PubKeyAminoName,
 }
 
 //-------------------------------------------------------
@@ -107,6 +110,11 @@ func (tm2pb) PubKey(pubKey crypto.PubKey) abci.PubKey {
 	case secp256k1.PubKeySecp256k1:
 		return abci.PubKey{
 			Type: ABCIPubKeyTypeSecp256k1,
+			Data: pk[:],
+		}
+	case p256.PubKeyP256:
+		return abci.PubKey{
+			Type:ABCIPubKeyTypeP256,
 			Data: pk[:],
 		}
 	default:
@@ -202,6 +210,14 @@ func (pb2tm) PubKey(pubKey abci.PubKey) (crypto.PubKey, error) {
 				len(pubKey.Data), secp256k1.PubKeySecp256k1Size)
 		}
 		var pk secp256k1.PubKeySecp256k1
+		copy(pk[:], pubKey.Data)
+		return pk, nil
+	case ABCIPubKeyTypeP256:
+		if len(pubKey.Data) != p256.PubKeyP256Size {
+			return nil, fmt.Errorf("Invalid size for P256. Got %d, expected %d",
+				len(pubKey.Data), p256.PubKeyP256Size)
+		}
+		var pk p256.PubKeyP256
 		copy(pk[:], pubKey.Data)
 		return pk, nil
 	default:


### PR DESCRIPTION
# Error list
## consensus/TestByzantine
types/protobuf.go에서 public key를 처리하는 과정에서 p256에 대한 조건을 설정해주지 않아서 발생

## crypto/encoding/animo/ExamplePrintRegisteredTypes
ExamplePrintRegisteredTypes의 조건에 p256을 추가하지 않아서 발생

## 일부 revert
p2p와 validator 관련 코드에서 p256을 사용하도록 수정되었던 것을 revert함. 실제 이 부분들은 client와는 직접 연관되지 않기 때문이다. client 외에 p2p node들과 validator들이 사용하는 모든 알고리즘에서 p256을 사용하도록 하는 작업은 별도로 실행하기로 함.